### PR TITLE
Create copy_dll.bat

### DIFF
--- a/src/copy_dll.bat
+++ b/src/copy_dll.bat
@@ -1,0 +1,14 @@
+@echo off
+title *******************************************************dlls files copying script***********************************************************************
+color 0A
+echo.
+xcopy /y C:\work\tips\pts\C462\common\02-Web\Tips.Pts.C462.Common.Web\bin\Debug\Tips.Pts.C462.Common.Web.dll C:\debug\dbgshr
+xcopy /y C:\work\tips\pts\C462\common\02-Web\Tips.Pts.C462.Common.Web\bin\Debug\Tips.Pts.C462.Common.Web.dll.config C:\debug\dbgshr
+xcopy /y C:\work\tips\pts\C462\common\02-Web\Tips.Pts.C462.Common.Web\bin\Debug\Tips.Pts.C462.Common.Web.xml C:\debug\dbgshr
+xcopy /y C:\work\tips\pts\C462\common\02-Web\Tips.Pts.C462.Common.Web\bin\Debug\Tips.Pts.C462.Common.Web.pdb C:\debug\dbgshr
+echo.
+echo --------------------------------------------------------------------
+echo all C462.common.web dlls files has been copied to C:\debug\dbgshr
+echo --------------------------------------------------------------------
+echo.
+pause


### PR DESCRIPTION
This is a script for copying dlls from 
_**C:\work\tips\pts\C462\common\02-Web\Tips.Pts.C462.Common.Web\bin\Debug**_
 to
 **_C:\debug\dbgshr_**

### files copied

1. Tips.Pts.C462.Common.Web.dll
2. Tips.Pts.C462.Common.Web.xml
3. Tips.Pts.C462.Common.Web.pdb
4. Tips.Pts.C462.Common.Web.dll.config